### PR TITLE
Make hyperlinks and references "reader friendly"

### DIFF
--- a/comprehensive-gpl-guide.tex
+++ b/comprehensive-gpl-guide.tex
@@ -65,13 +65,13 @@
 %   http://tex.stackexchange.com/questions/77886/fncychap-and-hyperref-messes-up-page-references
 \usepackage[colorlinks=true]{hyperref}
 \usepackage{xcolor}
-\definecolor{c1}{rgb}{0,0,1}
-\definecolor{c2}{rgb}{0,0.3,0.9}
-\definecolor{c3}{rgb}{0.3,0,0.9}
+\definecolor{c1}{rgb}{0,0,1} % blue
+\definecolor{c2}{rgb}{0,0.3,0.9} % light blue
+\definecolor{c3}{rgb}{0.3,0,0.9} % red blue
 \hypersetup{
-    linkcolor=c1,
-    citecolor=c2,
-    urlcolor=c3
+    linkcolor=c1, % internal links
+    citecolor=c2, % citations
+    urlcolor=c3   % external links/urls
 }
 \newcommand{\tutorialpartsplit}[2]{#2}
 

--- a/comprehensive-gpl-guide.tex
+++ b/comprehensive-gpl-guide.tex
@@ -63,8 +63,16 @@
            ]{geometry}
 % Make sure hyperref is last in the package list.  Order matters here, See:
 %   http://tex.stackexchange.com/questions/77886/fncychap-and-hyperref-messes-up-page-references
-\usepackage{hyperref}
-
+\usepackage[colorlinks=true]{hyperref}
+\usepackage{xcolor}
+\definecolor{c1}{rgb}{0,0,1}
+\definecolor{c2}{rgb}{0,0.3,0.9}
+\definecolor{c3}{rgb}{0.3,0,0.9}
+\hypersetup{
+    linkcolor=c1,
+    citecolor=c2,
+    urlcolor=c3
+}
 \newcommand{\tutorialpartsplit}[2]{#2}
 
 %\input{no-numbers-on-table-of-contents}

--- a/gpl-lgpl.tex
+++ b/gpl-lgpl.tex
@@ -99,7 +99,7 @@ principles.
 \label{Free Software Definition}
 
 The Free Software Definition is set forth in full on FSF's website at
-\verb0http://fsf.org/0 \verb0philosophy/free-sw.html0. This section presents
+\url{https://www.fsf.org/%20philosophy/free-sw.html}. This section presents
 an abbreviated version that will focus on the parts that are most pertinent
 to the GPL\@.
 
@@ -380,7 +380,7 @@ Section~\ref{Free Software Definition} are all granted because there is no
 legal system in play to take them away.
 
 Admittedly, a discussion of public domain software is an oversimplified
-example.  
+example.
 Because copyright controls are usually automatically granted and because, in
 some jurisdictions, some copyright controls cannot be waived (see
 Section~\ref{non-usa-copyright} for further discussion), many copyright
@@ -761,7 +761,7 @@ from June 1991 to June 2007 --- there was really only one version of the GPL,
 version 2.
 
 However, the GPL had both earlier versions before version 2, and, more well
-known, a revision to version 3. 
+known, a revision to version 3.
 
 \section{Historical Motivations for the General Public License}
 
@@ -1407,10 +1407,10 @@ identical in order to be held a derivative work of an original, while
 
 \section{No Protection for ``Methods of Operation''}
 
-The First Circuit has taken the position that the AFC test is inapplicable 
-when the works in question relate to unprotectable elements set forth in 
+The First Circuit has taken the position that the AFC test is inapplicable
+when the works in question relate to unprotectable elements set forth in
 \S~102(b).  Their approach results in a much narrower definition
-of derivative work for software in comparison to other circuits. Specifically, 
+of derivative work for software in comparison to other circuits. Specifically,
 the
 First Circuit holds that ``method of operation,'' as used in \S~102(b) of
 the Copyright Act, refers to the means by which users operate
@@ -1424,7 +1424,7 @@ of a menu command hierarchy, or any other ``method of operation,'' cannot
 form the basis for a determination that one work is a derivative of
 another.  As a result, courts in the First Circuit that apply the AFC test
 do so only after applying a broad interpretation of \S~102(b) to filter out
-unprotected elements. E.g., Real View, LLC v. 20-20 Technologies, Inc., 
+unprotected elements. E.g., Real View, LLC v. 20-20 Technologies, Inc.,
 683 F. Supp.2d 147, 154 (D. Mass. 2010).
 
 
@@ -1470,23 +1470,23 @@ to support a finding of infringement because they were too simple and
 obvious to contain any original expression.
 
 In the case of Oracle America v. Google, 872 F. Supp.2d 974 (N.D. Cal. 2012),
-the Northern District of California District Court examined the question of 
+the Northern District of California District Court examined the question of
 whether the application program interfaces (APIs) associated with the Java
-programming language are entitled to copyright protection.  While the 
-court expressly declined to rule whether all APIs are free to use without 
-license (872 F. Supp.2d 974 at 1002), the court held that the command 
+programming language are entitled to copyright protection.  While the
+court expressly declined to rule whether all APIs are free to use without
+license (872 F. Supp.2d 974 at 1002), the court held that the command
 structure and taxonomy of the APIs were not protectable under copyright law.
 Specifically, the court characterized the command structure and taxonomy as
-both a ``method of operation'' (using an approach not dissimilar to the 
-First Circuit's analysis in Lotus) and a ``functional requirement for 
+both a ``method of operation'' (using an approach not dissimilar to the
+First Circuit's analysis in Lotus) and a ``functional requirement for
 compatibility'' (using Sega v. Accolade, 977 F.2d 1510 (9th Cir. 1992) and
 Sony Computer Ent. v. Connectix, 203 F.3d 596 (9th Cir. 2000) as analogies),
-and thus unprotectable subject matter under \S~102(b). 
+and thus unprotectable subject matter under \S~102(b).
 
 Perhaps not surprisingly, there have been few other cases involving a highly
 detailed software derivative work analysis. Most often, cases involve
 clearer basis for decision, including frequent bad faith on the part of
-the defendant or over-aggressiveness on the part of the plaintiff.  
+the defendant or over-aggressiveness on the part of the plaintiff.
 
 \section{How Much Do Derivative Works Matter?}
 
@@ -1745,7 +1745,7 @@ copy of the software.
 In summary, GPLv2\ 2(b) says what terms under which the third parties must
 receive this no-charge license.  Namely, they receive it ``under the terms
 of this License'', the GPLv2.  When an entity \emph{chooses} to redistribute
-a work based on GPL'd software, the license of that whole 
+a work based on GPL'd software, the license of that whole
 work must be GPL and only GPL\@.  In this manner, GPLv2~\S2(b) dovetails nicely
 with GPLv2~\S6 (as discussed in Section~\ref{GPLv2s6} of this tutorial).
 
@@ -1768,7 +1768,7 @@ as long as the terms of GPL are adhered to for those packages that are
 truly GPL'd.
 
 %FIXME: need discussion of GPLv2's system library exception somewhere in here.
-\subsection{Right to Private Modification} 
+\subsection{Right to Private Modification}
 \label{gplv2-private-modification}
 
 The issue of private modifications of GPLv2'd works deserves special
@@ -2063,13 +2063,13 @@ the parties might reasonably contemplate the product will be put.'' A
 clever advocate may argue that the implied license granted by GPLv2 is
 larger in scope than the express license in other Free Software
 licenses with express patent grants, in that the patent license
-clause of many of those other Free  Software licenses are specifically 
+clause of many of those other Free  Software licenses are specifically
 limited to the patent claims covered by the code as licensed by the patentee.
 
-In contrast, a GPLv2 licensee, under the doctrine of implied patent license, 
-is free to practice any patent claims held by the licensor that cover 
-``reasonably contemplated uses'' of the GPL'd code, which may very well 
-include creation and distribution of modified works since the GPL's terms, 
+In contrast, a GPLv2 licensee, under the doctrine of implied patent license,
+is free to practice any patent claims held by the licensor that cover
+``reasonably contemplated uses'' of the GPL'd code, which may very well
+include creation and distribution of modified works since the GPL's terms,
 under which the patented code is distributed, expressly permits such activity.
 
 
@@ -2107,7 +2107,7 @@ with respect to the licensed software.
 
 For example, if Company \compA{} has a patent on advanced Web browsing, but
 also licenses a Web browsing program under the GPLv2, then it
-cannot assert the patent against any party based on that party's use of 
+cannot assert the patent against any party based on that party's use of
 Company \compA{}'s GPL'd Web browsing software program, or on that party's
 creation and use of modified versions of that GPL'd program.  However, if a
 party uses that program without
@@ -2115,7 +2115,7 @@ complying with the GPLv2, then Company \compA{} can assert both copyright
 infringement claims against the non-GPLv2-compliant party and
 infringement of the patent, because the implied patent license only
 extends to use of the software in accordance with the GPLv2. Further, if
-Company \compB{} distributes a competitive advanced Web browsing program 
+Company \compB{} distributes a competitive advanced Web browsing program
 that is not a modified version of Company \compA{}'s GPL'd Web browsing software
 program, Company \compA{} is free to assert its patent against any user or
 distributor of that product. It is irrelevant whether Company \compB's
@@ -2660,7 +2660,7 @@ wording with neutral terminology rooted in description of behavior rather
 than specific statute.  As can be seen in the section-by-section discussion of
 GPLv3 that follows, nearly every section had changes related to issues of
 internationalization.
- 
+
 \section{GPLv3~\S0: Giving In On ``Defined Terms''}
 \label{GPLv3s0}
 
@@ -2684,7 +2684,7 @@ discusses a few of the new ones.
 
 GPLv3~\S0 includes definitions of five new terms not found in any form in
 GPLv2: ``modify'' ``covered work'', ``propagate'', ``convey'', and
-``Appropriate Legal Notices''. 
+``Appropriate Legal Notices''.
 
 \subsection{Modify and the Work Based on the Program}
 
@@ -2795,7 +2795,7 @@ automatically  accounts for all exclusive rights under that regime.
 Next, GPLv3 defines a subset of propagate --- ``convey''.
 Conveying includes activities that constitute propagation of copies to
 others.  As with the definition of propagate, GPLv3 thus addresses transfers
-of copies of software in behavioral rather than statutory terms.  
+of copies of software in behavioral rather than statutory terms.
 Any propagation that enables other parties to receive or make copies of the
 work, is called ``conveying''.  Usually, conveying is the activity that
 triggers most of the other obligations of GPLv3.
@@ -3283,7 +3283,7 @@ in operation for required period.  This codifies formally the typical
 historical interpretation of GPLv2.
 
 % FIXME-LATER: perhaps in enforcement section, but maybe here, note about
-% ``slow down'' on source downloads being a compliance problem. 
+% ``slow down'' on source downloads being a compliance problem.
 
 Furthermore, under GPLv3~\S6(d), distributors may charge for the conveyed
 object code; however, those who pay to obtain the object code must be given
@@ -3545,13 +3545,13 @@ merely through a ``failure to enforce'' estoppel-esque scenario.  Therefore, GPL
 for some specific limited requirement variations that GPLv2 technically prohibits.
 
 With these principles in the background, GPLv3~\S7  answers the following
-questions: 
+questions:
 \begin{enumerate}
 \item How does the presence of additional terms on all or part of a GPL'd program
 affect users' rights?
 
 \item When and how may a licensee add terms to code being
-distributed under the GPL? 
+distributed under the GPL?
 
 \item When may a licensee remove additional terms?
 \end{enumerate}
@@ -3561,7 +3561,7 @@ permissive exceptions often appeared alongside GPLv2 to allow combination
 with certain non-free code.  Typically, downstream
 stream recipients could remove those exceptions and operate under pure GPLv2.
 Similarly, LGPLv2.1 is in essence a permissive variant of GPLv2,
-and it permits relicensing under the GPL\@.  
+and it permits relicensing under the GPL\@.
 
 These practices are now generalized via GPLv3~\S7.
 A licensee may remove any additional permission from
@@ -3622,7 +3622,7 @@ exceptions for certain kinds of combinations.
 
 GPLv3~\S7  implements a more explicit policy on license
 compatibility.  It formalizes the circumstances under which a licensee may
-release a covered work that includes an added part carrying non-GPL terms. 
+release a covered work that includes an added part carrying non-GPL terms.
 GPLv3~\S7 distinguish between terms that provide additional permissions, and terms that
 place additional requirements on the code, relative to the permissions and
 requirements established by applying the GPL to the code.
@@ -3639,7 +3639,7 @@ In its treatment of terms that impose additional requirements, GPLv3\S7
 extends the range of licensing terms with which the GPL is compatible.  An
 added part carrying additional requirements may be combined with GPL'd code,
 but only if those requirements belong to a set enumerated in GPLv3\S7. There
-are, of course, limits on the acceptable additional requirements, which 
+are, of course, limits on the acceptable additional requirements, which
 ensures that enhanced license compatibility does not
 defeat the broader software-freedom-defending terms of the GPL\@. Unlike terms that grant
 additional permissions, terms that impose additional requirements cannot be
@@ -3687,7 +3687,7 @@ requirements hat GPLv3 are as follows:
       advertising clause} that the FSF
     \href{https://www.gnu.org/philosophy/bsd.html}{long ago identified as
       problematic}.
- 
+
 \item This provision clarifies that refusal to grant trademark rights for a
   GPLv3'd covered work remains compatible with GPLv3.  Again, some
   non-copyleft permissive licenses include such clauses.
@@ -3894,7 +3894,7 @@ The argument that the impact of the patent license grant would be
 ``disproportionate'',  that is to say unfair, is not valid. Since
 software patents are weapons that no one should have, and using them for
 aggression against free software developers is an egregious act (thus
-preventing that act cannot be unfair). 
+preventing that act cannot be unfair).
 
 However, the second argument seems valid in a practical sense.  A
 typical GNU/Linux distribution includes thousands of programs.  It would
@@ -3904,7 +3904,7 @@ and passes on a new version of the distribution.  Moreover, this question
 raises a strategic issue. If the GPLv3 patent license requirements
 convince patent-holding companies to remain outside the distribution
 path of all GPL-covered software, then these requirements, no matter how
-strong, will cover few patents. 
+strong, will cover few patents.
 
 GPLv3 therefore makes a partial concession
 which would lead these companies to feel secure in doing the
@@ -3912,7 +3912,7 @@ distribution themselves. GPLv3~\S11
 applies only to those distributors that have
 modified the program.  The other changes we have made in sections 10 and
 11 provide strengthened defenses against patent assertion and compensate
-partly for this concession. 
+partly for this concession.
 
 Therefore, GPLv3~\S11 introduces the terms ``contributor'', ``contributor version'', and
 ``essential patent claims'', which are
@@ -4084,11 +4084,11 @@ this make a mockery of free software, and we must do everything in our power
 to stop them.
 
 First, GPLv3~\S11\P6 states that any license that protects some recipients of
-GPL'd software must be extended to all recipients of the software.  
+GPL'd software must be extended to all recipients of the software.
 If conveyors arrange to provide patent
 protection to some of the people who get the software from you, that
 protection is automatically extended to everyone who receives the software,
-no matter how they get it. 
+no matter how they get it.
 
 Second, GPLv3~\S11\P7
 prohibits anyone who made such an agreement from distributing software
@@ -4112,7 +4112,7 @@ that Microsoft has acquired that essentially commit it to participate
 in the distribution of the Novell SLES GNU/Linux system.
 
 The FSF also gave a secondary reason:  to avoid affecting other kinds of agreements for
-other kinds of activities.  While GPLv3 sought to 
+other kinds of activities.  While GPLv3 sought to
 distinguish pernicious deals of the Microsoft/Novell type from
 business conduct that is not particularly harmful, the FSF also did not
 assume success in that drafting, and thus there remained some risk that other
@@ -4159,7 +4159,7 @@ Meanwhile, there was disagreement even among copyleft enthusiasts about the
 importance of the provision.  A coalition never formed, and ultimately the
 more powerful interests implicitly allied with the companies who deeply opposed
 the Affero clause such that the FSF felt the Affero clause would need its own
-license, but one compatible with GPLv3. 
+license, but one compatible with GPLv3.
 
 GPLv3~\S13 makes GPLv3 compatible with the AGPLv3, so that at least code can
 be shared between AGPLv3'd and GPLv3'd projects, even if the Affero clause
@@ -4301,7 +4301,7 @@ Terms to Your New Programs'' to just the bare essentials.
 As we have seen in our consideration of the GPL, its text is specifically
 designed to cover all possible derivative, modified and/or combined works under copyright law. Our
 goal in designing the GPL was to maximize its use of the controls of
-copyright law to maximize the number of works that were covered by GPL. 
+copyright law to maximize the number of works that were covered by GPL.
 
 However, while the strategic goal of software freedom is to bring as much Free Software
 into the world as possible, particular tactical considerations
@@ -4746,7 +4746,7 @@ If such a mechanism is used, it must allow the user to upgrade and
 replace the library with interface-compatible versions and still be able
 to use the ``work that uses the library.''  However, all modern shared
 library mechanisms function as such, and thus LGPLv2.1~\S6(b) is the simplest
-option, since it does not even require that the distributor of the ``work 
+option, since it does not even require that the distributor of the ``work
 based on the library'' ship copies of the library itself.
 
 LGPLv2.1~\S6(a) is the option to use when, for some reason, a shared library
@@ -4788,7 +4788,7 @@ GPLv3. Compliance requires slightly different measures with respect to the
 \section{Distributing Works Based On the Library}
 
 Essentially, ``works based on the library'' must be distributed under the
-same conditions as works under full GPL\@. In fact, we note that 
+same conditions as works under full GPL\@. In fact, we note that
 LGPLv2.1~\S2 is nearly identical in its terms and requirements to GPLv2~\S2.
 
 There are, however, subtle differences and additions.  For example not only
@@ -5126,4 +5126,3 @@ compliance and compliance case studies.
 %%  LocalWords:  GPLRequireSourcePostedPublic privity Downstream's Jaeger
 %%  LocalWords:  Jaeger's copyleft's executables estoppel infringer
 %%  LocalWords:  unenforceability enforceability CISG
-

--- a/gpl-lgpl.tex
+++ b/gpl-lgpl.tex
@@ -99,7 +99,7 @@ principles.
 \label{Free Software Definition}
 
 The Free Software Definition is set forth in full on FSF's website at
-\url{https://www.fsf.org/%20philosophy/free-sw.html}. This section presents
+\url{https://www.fsf.org/philosophy/free-sw.html}. This section presents
 an abbreviated version that will focus on the parts that are most pertinent
 to the GPL\@.
 


### PR DESCRIPTION
Hyperlinks and references were represented by some awful rectangular box. The commits in this PR gets rid of those boxes, at the same time adds color styles to all internal and external links in the entire document.